### PR TITLE
feat(aarch64): add support for aarch64

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -58,7 +58,7 @@ get_arch() {
   x86_64)
     arch='amd64'
     ;;
-  arm64)
+  arm64 | aarch64)
     arch='arm64'
     ;;
   esac


### PR DESCRIPTION
Hi,

When using `asdf-kpt` on a Mac (Apple M1 Max) in a container, it fails to download the correct `kpt-binary`.

When running `uname -m` in a container on my Mac, it shows: `aarch64`.

In your [install.sh:55](https://github.com/nlamirault/asdf-kpt/blob/master/bin/install#L55), `aarch64`is passed through the switch/case statement if it doesn't match `x86_64` or `arm64`. 
In my case, it means `aarch64` is passed on to the `download_url` which causes `curl` to download:
https://github.com/GoogleContainerTools/kpt/releases/download/v1.0.0-beta.55/kpt_linux_aarch64-1.0.0-beta.55.tar.gz

Unfortunately, that URL doesn't exist as the `kpt-binary` contains `arm64` instead of `aarch64`.
From `kpt` release:
https://github.com/kptdev/kpt/releases/download/v1.0.0-beta.55/kpt_linux_arm64-1.0.0-beta.55.tar.gz


This PR fixes the above by adding `aarch64`to the switch/case that determines the name of the architecture in the `kpt-binary`.
